### PR TITLE
refactor: separate slacknotification and slackmessage into distinct packages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,3 +5,11 @@ go 1.21.1
 require github.com/joho/godotenv v1.5.1
 
 require github.com/a8m/envsubst v1.4.2
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/jarcoal/httpmock v1.3.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.8.4 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,15 @@
 github.com/a8m/envsubst v1.4.2 h1:4yWIHXOLEJHQEFd4UjrWDrYeYlV7ncFWJOCBRLOZHQg=
 github.com/a8m/envsubst v1.4.2/go.mod h1:MVUTQNGQ3tsjOOtKCNd+fl8RzhsXcDvvAEzkhGtlsbY=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/jarcoal/httpmock v1.3.1 h1:iUx3whfZWVf3jT01hQTO/Eo5sAYtB2/rqaUuOtpInww=
+github.com/jarcoal/httpmock v1.3.1/go.mod h1:3yb8rc4BI7TCBhFY8ng0gjuLKJNquuDNiPaZjnENuYg=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/src/scripts/main.go
+++ b/src/scripts/main.go
@@ -7,10 +7,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/CircleCI-Public/slack-orb-go/src/scripts/httputils"
 	"github.com/CircleCI-Public/slack-orb-go/src/scripts/ioutils"
-	"github.com/CircleCI-Public/slack-orb-go/src/scripts/jsonutils"
-	"github.com/CircleCI-Public/slack-orb-go/src/scripts/stringutils"
+	"github.com/CircleCI-Public/slack-orb-go/src/scripts/slackmessage"
+	"github.com/CircleCI-Public/slack-orb-go/src/scripts/slacknotification"
 
 	"github.com/a8m/envsubst"
 	"github.com/joho/godotenv"
@@ -60,98 +59,28 @@ func main() {
 	ignoreErrorsStr, _ = envsubst.String(ignoreErrorsStr)
 	tagPattern, _ = envsubst.String(tagPattern)
 
-	// Exit if required environment variables are not set
-	if accessToken == "" {
-		log.Fatalf(
-			"In order to use the Slack Orb (v4 +), an OAuth token must be present via the SLACK_ACCESS_TOKEN environment variable." +
-				"\nFollow the setup guide available in the wiki: https://github.com/CircleCI-Public/slack-orb/wiki/Setup.",
-		)
-	}
-	if channelsStr == "" {
-		log.Fatalf(
-			`No channel was provided. Please provide one or more channels using the "SLACK_PARAM_CHANNEL" environment variable or the "channel" parameter.`,
-		)
-	}
-
-	// Exit if the job status does not match the message send event and the message send event is not set to "always"
-	if !stringutils.IsEventMatchingStatus(eventToSendMessage, jobStatus) {
-		message := fmt.Sprintf("The job status %q does not match the status set to send alerts %q.", jobStatus, eventToSendMessage)
+	invertMatch, _ := strconv.ParseBool(invertMatchStr)
+	ignoreErrors, _ := strconv.ParseBool(ignoreErrorsStr)
+	channels := strings.Split(channelsStr, ",")
+	
+	slackNotification := slacknotification.NewSlackNotification(jobStatus, jobBranch, jobTag, eventToSendMessage, branchPattern, tagPattern, inlineTemplate, envVarContainingTemplate, invertMatch)
+	modifiedJSON := slackNotification.BuildMessageBody()
+	slackMessage := slackmessage.NewSlackMessage(modifiedJSON, accessToken, ignoreErrors, channels)
+	
+	if !slackNotification.IsEventMatchingStatus() {
+		message := fmt.Sprintf("The job status %q does not match the status set to send alerts %q.", slackNotification.Status, slackNotification.Event)
 		fmt.Println(message)
 		fmt.Println("Exiting without posting to Slack...")
 		os.Exit(0)
 	}
 
-	// Check if the branch and tag match their respective patterns and parse the invert match parameter
-	branchMatches, err := stringutils.IsPatternMatchingString(branchPattern, jobBranch)
-	if err != nil {
-		log.Fatal("Error parsing the branch pattern:", err)
-	}
-	tagMatches, err := stringutils.IsPatternMatchingString(tagPattern, jobTag)
-	if err != nil {
-		log.Fatal("Error parsing the tag pattern:", err)
-	}
-	invertMatch, _ := strconv.ParseBool(invertMatchStr)
-	if !stringutils.IsPostConditionMet(branchMatches, tagMatches, invertMatch) {
+	if !slackNotification.IsPostConditionMet() {
 		fmt.Println("The post condition is not met. Neither the branch nor the tag matches the pattern or the match is inverted.")
 		fmt.Println("Exiting without posting to Slack...")
 		os.Exit(0)
 	}
 
-	// Build the message body
-	template, err := jsonutils.DetermineTemplate(inlineTemplate, jobStatus, envVarContainingTemplate)
-	if err != nil {
-		log.Fatalf("%v", err)
-	}
-	if template == "" {
-		log.Fatalf("the template %q is empty. Exiting without posting to Slack...", template)
-	}
-
-	// Expand environment variables in the template
-	templateWithExpandedVars, err := jsonutils.ApplyFunctionToJSON(template, jsonutils.ExpandEnvVarsInInterface)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// Add a "channel" property with a nested "myChannel" property
-	modifiedJSON, err := jsonutils.ApplyFunctionToJSON(templateWithExpandedVars, jsonutils.AddRootProperty("channel", "my_channel"))
-	if err != nil {
-		log.Fatalf("%v", err)
-	}
-
-	ignoreErrors, _ := strconv.ParseBool(ignoreErrorsStr)
-	channels := strings.Split(channelsStr, ",")
-	for _, channel := range channels {
-		// Add a "channel" property with the current channel
-		jsonWithChannel, err := jsonutils.ApplyFunctionToJSON(modifiedJSON, jsonutils.AddRootProperty("channel", channel))
-		if err != nil {
-			log.Fatalf("%v", err)
-		}
-		fmt.Printf("Posting the following JSON to Slack:\n%s\n", jsonWithChannel)
-
-		// Post the message to Slack
-		headers := map[string]string{
-			"Content-Type":  "application/json",
-			"Authorization": "Bearer " + accessToken,
-		}
-		response, err := httputils.SendHTTPRequest("POST", "https://slack.com/api/chat.postMessage", jsonWithChannel, headers)
-		if err != nil {
-			log.Fatalf("Error posting to Slack: %v", err)
-		}
-		fmt.Printf("Slack API response:\n%s\n", response)
-
-		// Check if the Slack API returned an error message
-		errorMsg, err := jsonutils.ApplyFunctionToJSON(response, jsonutils.ExtractRootProperty("error"))
-		if err != nil {
-			log.Fatalf("Error extracting error message: %v", err)
-		}
-
-		// Exit if the Slack API returned an error message and the ignore errors parameter is not set to true
-		if errorMsg != "" {
-			fmt.Printf("Slack API returned an error message:\n%s", errorMsg)
-			fmt.Println("\n\nView the Setup Guide: https://github.com/CircleCI-Public/slack-orb/wiki/Setup")
-			if !ignoreErrors {
-				os.Exit(1)
-			}
-		}
+	for _, channel := range slackMessage.Channels {
+		slackMessage.PostMessage(channel)
 	}
 }

--- a/src/scripts/slackmessage/slackmessage.go
+++ b/src/scripts/slackmessage/slackmessage.go
@@ -1,0 +1,45 @@
+package slackmessage
+
+import (
+	"fmt"
+	"os"
+	"github.com/CircleCI-Public/slack-orb-go/src/scripts/httputils"
+	"github.com/CircleCI-Public/slack-orb-go/src/scripts/jsonutils"
+)
+
+type SlackMessage struct {
+	Template      string
+	AccessToken   string
+	IgnoreErrors  bool
+	Channels      []string
+}
+
+func NewSlackMessage (template string, accessToken string, ignoreErrors bool, channels []string) *SlackMessage{
+	return &SlackMessage{
+		Template: template,
+		AccessToken: accessToken,
+		IgnoreErrors: ignoreErrors,
+		Channels: channels,
+	}
+}
+
+func (s *SlackMessage) PostMessage(channel string) {
+	jsonWithChannel, _ := jsonutils.ApplyFunctionToJSON(s.Template, jsonutils.AddRootProperty("channel", channel))
+	fmt.Printf("Posting the following JSON to Slack:\n%s\n", jsonWithChannel)
+
+	headers := map[string]string{
+		"Content-Type":  "application/json",
+		"Authorization": "Bearer " + s.AccessToken,
+	}
+	response, _ := httputils.SendHTTPRequest("POST", "https://slack.com/api/chat.postMessage", jsonWithChannel, headers)
+	fmt.Printf("Slack API response:\n%s\n", response)
+
+	errorMsg, _ := jsonutils.ApplyFunctionToJSON(response, jsonutils.ExtractRootProperty("error"))
+	if errorMsg != "" {
+		fmt.Printf("Slack API returned an error message:\n%s", errorMsg)
+		fmt.Println("\n\nView the Setup Guide: https://github.com/CircleCI-Public/slack-orb/wiki/Setup")
+		if !s.IgnoreErrors {
+			os.Exit(1)
+		}
+	}
+}

--- a/src/scripts/slackmessage/slackmessage_test.go
+++ b/src/scripts/slackmessage/slackmessage_test.go
@@ -1,0 +1,67 @@
+package slackmessage
+
+import (
+	"io"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSlackMessage(t *testing.T) {
+	template := "template"
+	accessToken := "token"
+	ignoreErrors := false
+	channels := []string{"channel1", "channel2"}
+
+	expected := &SlackMessage{
+		Template:     template,
+		AccessToken:  accessToken,
+		IgnoreErrors: ignoreErrors,
+		Channels:     channels,
+	}
+
+	actual := NewSlackMessage(template, accessToken, ignoreErrors, channels)
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected and actual do not match. Expected: %v, Actual: %v", expected, actual)
+	}
+}
+
+func TestPostMessage(t *testing.T) {
+	// Create a new SlackMessage
+	s := &SlackMessage{
+		AccessToken:  "test_token",
+		Template:     "{}",
+		IgnoreErrors: true,
+	}
+
+	// Activate the httpmock
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	// Mock the Slack API response
+	httpmock.RegisterResponder("POST", "https://slack.com/api/chat.postMessage",
+		httpmock.NewStringResponder(200, `{"ok": true}`))
+
+	// Capture the stdout
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	// Call the function
+	s.PostMessage("test_channel")
+
+	// Close the pipe and restore the original stdout
+	w.Close()
+	os.Stdout = oldStdout
+
+	// Read the captured stdout
+	out, _ := io.ReadAll(r)
+
+	// Assert that the function printed the correct output
+	assert.Contains(t, string(out), "Posting the following JSON to Slack:")
+	assert.Contains(t, string(out), "Slack API response:")
+}

--- a/src/scripts/slacknotification/slacknotification.go
+++ b/src/scripts/slacknotification/slacknotification.go
@@ -1,0 +1,71 @@
+package slacknotification
+
+import (
+	"log"
+	
+	"github.com/CircleCI-Public/slack-orb-go/src/scripts/stringutils"
+	"github.com/CircleCI-Public/slack-orb-go/src/scripts/jsonutils"
+)
+
+type SlackNotification struct {
+	Status        string
+	Branch        string
+	Tag           string
+	Event         string
+	BranchPattern string
+	TagPattern    string
+	InvertMatch   bool
+	Template      string
+	InlineTemplate string
+	EnvVarContainingTemplate string
+}
+
+func NewSlackNotification(status, branch, tag, event, branchPattern, tagPattern, inlineTemplate, envVarContainingTemplate string, invertMatch bool) *SlackNotification {
+	return &SlackNotification{
+		Status:        status,
+		Branch:        branch,
+		Tag:           tag,
+		Event:         event,
+		BranchPattern: branchPattern,
+		TagPattern:    tagPattern,
+		InvertMatch:   invertMatch,
+		InlineTemplate: inlineTemplate,
+		EnvVarContainingTemplate: envVarContainingTemplate,
+	}
+}
+
+func (j *SlackNotification) IsEventMatchingStatus() bool {
+	return stringutils.IsEventMatchingStatus(j.Event, j.Status)
+}
+
+func (j *SlackNotification) IsPostConditionMet() bool {
+	branchMatches, _ := stringutils.IsPatternMatchingString(j.BranchPattern, j.Branch)
+	tagMatches, _ := stringutils.IsPatternMatchingString(j.TagPattern, j.Tag)
+	return stringutils.IsPostConditionMet(branchMatches, tagMatches, j.InvertMatch)
+}
+
+func (j *SlackNotification) BuildMessageBody() string {
+	// Build the message body
+	template, err := jsonutils.DetermineTemplate(j.InlineTemplate, j.Status, j.EnvVarContainingTemplate)
+	if err != nil {
+		log.Fatalf("%v", err)
+	}
+	if template == "" {
+		log.Fatalf("the template %q is empty. Exiting without posting to Slack...", template)
+	}
+
+	// Expand environment variables in the template
+	templateWithExpandedVars, err := jsonutils.ApplyFunctionToJSON(template, jsonutils.ExpandEnvVarsInInterface)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Add a "channel" property with a nested "myChannel" property
+	modifiedJSON, err := jsonutils.ApplyFunctionToJSON(templateWithExpandedVars, jsonutils.AddRootProperty("channel", "my_channel"))
+	if err != nil {
+		log.Fatalf("%v", err)
+	}
+
+	return modifiedJSON
+}
+

--- a/src/scripts/slacknotification/slacknotification_test.go
+++ b/src/scripts/slacknotification/slacknotification_test.go
@@ -1,0 +1,117 @@
+package slacknotification
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSlackNotification(t *testing.T) {
+	status := "success"
+	branch := "main"
+	tag := "v1.0"
+	event := "push"
+	branchPattern := "main"
+	tagPattern := "v1.*"
+	inlineTemplate := "template"
+	envVarContainingTemplate := "TEMPLATE_ENV"
+	invertMatch := false
+
+	notification := NewSlackNotification(status, branch, tag, event, branchPattern, tagPattern, inlineTemplate, envVarContainingTemplate, invertMatch)
+
+	assert.Equal(t, status, notification.Status)
+	assert.Equal(t, branch, notification.Branch)
+	assert.Equal(t, tag, notification.Tag)
+	assert.Equal(t, event, notification.Event)
+	assert.Equal(t, branchPattern, notification.BranchPattern)
+	assert.Equal(t, tagPattern, notification.TagPattern)
+	assert.Equal(t, inlineTemplate, notification.InlineTemplate)
+	assert.Equal(t, envVarContainingTemplate, notification.EnvVarContainingTemplate)
+	assert.Equal(t, invertMatch, notification.InvertMatch)
+}
+func TestIsEventMatchingStatus(t *testing.T) {
+	tests := []struct {
+		name   string
+		event  string
+		status string
+		want   bool
+	}{
+		{
+			name:   "matching event and status",
+			event:  "push",
+			status: "push",
+			want:   true,
+		},
+		{
+			name:   "non-matching event and status",
+			event:  "push",
+			status: "pull",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sn := NewSlackNotification(tt.status, "", "", tt.event, "", "","","", false)
+			got := sn.IsEventMatchingStatus()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIsPostConditionMet(t *testing.T) {
+	tests := []struct {
+		name          string
+		branch        string
+		tag           string
+		branchPattern string
+		tagPattern    string
+		invertMatch   bool
+		want          bool
+	}{
+		{
+			name:          "matching branch and tag patterns",
+			branch:        "main",
+			tag:           "v1.0",
+			branchPattern: "main",
+			tagPattern:    "v1.*",
+			invertMatch:   false,
+			want:          true,
+		},
+		{
+			name:          "non-matching branch and tag patterns",
+			branch:        "dev",
+			tag:           "v2.0",
+			branchPattern: "main",
+			tagPattern:    "v1.*",
+			invertMatch:   false,
+			want:          false,
+		},
+		{
+			name:          "invert match",
+			branch:        "dev",
+			tag:           "v2.0",
+			branchPattern: "main",
+			tagPattern:    "v1.*",
+			invertMatch:   true,
+			want:          true,
+		},
+		{
+			name:          "empty branch and tag",
+			branch:        "",
+			tag:           "",
+			branchPattern: "main",
+			tagPattern:    "v1.*",
+			invertMatch:   false,
+			want:          false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sn := NewSlackNotification("", tt.branch, tt.tag, "", tt.branchPattern, tt.tagPattern,"","", tt.invertMatch)
+			got := sn.IsPostConditionMet()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
This PR moves the validation for the Event Status and Event Status along with building the message body into the `slacknotifcation` package. 

It also move the posting of the slack message into a specific channel into the `slackmessage` package as well.  