### PR TITLE
refactor: downloading

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -36,9 +36,9 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Set "ORB_BOOL_RUN_FROM_SOURCE" flag to true to run the orb from source instead of downloading and running the GitHub binary.
+          name: Build Latest
           command: |
-            echo 'export ORB_BOOL_RUN_FROM_SOURCE=1' >> $BASH_ENV
+            go build -o ./.circleci/orbs/circleci/slack/Linux/x86_64/slack-orb-go ./src/scripts/main.go
           when: always      
       - slack/notify:
           debug: true


### PR DESCRIPTION
Previously, this orb had an internal flag that would tell the orb source to build the go binary rather than download it if set. This flag was meant purely for testing purposes and not for customer use.

This change modified the orb to instead skip the download process if the binary is already found locally. The build from source logic has been moved to the test job in CI. This skip logic has the added benefit of supporting caching.
![image](https://github.com/CircleCI-Public/slack-orb-go/assets/33272306/78257295-f736-40ec-99f2-a9fcbff62df1)
