### PR TITLE
test: alpine support

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -218,7 +218,7 @@ jobs:
       - run:
           name: Export variable with a multiline string
           command: |
-            printf '%s\n' 'export MULTILINE_STRING=$(printf "%s\\n" "Line 1." "Line 2." "Line 3.")' >> "$BASH_ENV"
+            printf 'export MULTILINE_STRING="Line 1.\\nLine 2.\\nLine 3."\n' >> "$BASH_ENV"
           when: always
       - slack/notify:
           debug: true

--- a/packages/cli/acceptance/acceptance_test.go
+++ b/packages/cli/acceptance/acceptance_test.go
@@ -40,7 +40,7 @@ func TestSlackOrbBinary(t *testing.T) {
 		},
 		expectedExitCode: 0,
 		expectedOutput:   "Successfully posted message to channel: test-channel",
-	},{
+	}, {
 		name: "Debug flag enabled",
 		environment: map[string]string{
 			"SLACK_ACCESS_TOKEN":  "test-token",
@@ -84,6 +84,29 @@ func TestSlackOrbBinary(t *testing.T) {
 			"SLACK_PARAM_CHANNEL": "test-channel",
 			"CCI_STATUS":          "fail",
 			"SLACK_PARAM_EVENT":   "pass",
+		},
+	}, {
+		name:             "Multiline string env var parsed correctly",
+		expectedExitCode: 0,
+		expectedOutput:   `This message should show over multiple lines: Line 1.\\nLine 2.\\nLine 3.`,
+		environment: map[string]string{
+			"SLACK_ACCESS_TOKEN":  "test-token",
+			"SLACK_PARAM_CHANNEL": "test-channel",
+			"CCI_STATUS":          "pass",
+			"SLACK_PARAM_EVENT":   "pass",
+			"SLACK_PARAM_DEBUG":   "true",
+			"MULTILINE_STRING":    `Line 1.\nLine 2.\nLine 3.`,
+			"SLACK_STR_TEMPLATE_INLINE": `{
+"blocks": [
+	{
+		"type": "section",
+		"text": {
+			"type": "mrkdwn",
+			"text": "This message should show over multiple lines: $MULTILINE_STRING"
+		}
+	}
+]
+}`,
 		},
 	}}
 


### PR DESCRIPTION
Properly adds support and testing for alpine.

Prior to this change, the way in which we set our environment variable for testing multiline strings was not compatible with ASH shell. The acceptance test added takes the shell out of the equation by setting the env var directly. With the env var reading correctly, we can see it was how the env var was set that caused the bad output.