### PR TITLE
fix: log

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,13 +9,14 @@
       "type": "go",
       "request": "launch",
       "mode": "auto",
-      "program": "${fileDirname}/main.go",
+      "program": "${workspaceFolder}/packages/cli/main.go",
       "args": ["notify"],
       "env": {
         "SLACK_ACCESS_TOKEN": "YOU_TOKEN",
         "SLACK_PARAM_CHANNEL": "YOUR_CHANNEL",
         "SLACK_PARAM_TEMPLATE": "YOUR_TEMPLATE",
-        "CCI_STATUS": "pass"
+        "CCI_STATUS": "pass",
+        "SLACK_PARAM_DEBUG": "1"
       }
     }
   ]

--- a/packages/cli/cmd/root.go
+++ b/packages/cli/cmd/root.go
@@ -31,6 +31,8 @@ var rootCmd = &cobra.Command{
 			log.Debug("Debug logging enabled")
 		}
 
+		initConfig()
+
 		if os.Getenv("CI") == "true" {
 			log.SetColorProfile(termenv.TrueColor)
 		}
@@ -48,8 +50,6 @@ func Execute() {
 }
 
 func init() {
-	cobra.OnInitialize(initConfig)
-
 	rootCmd.PersistentFlags().Bool("debug", false, "Enable debug logging")
 
 }

--- a/packages/cli/cmd/root.go
+++ b/packages/cli/cmd/root.go
@@ -27,16 +27,13 @@ var rootCmd = &cobra.Command{
 		}
 		debugValue := config.GetDebug()
 		if debugValue {
+			if os.Getenv("CI") == "true" {
+				log.SetColorProfile(termenv.TrueColor)
+			}
 			log.SetLevel(log.DebugLevel)
 			log.Debug("Debug logging enabled")
 		}
-
 		initConfig()
-
-		if os.Getenv("CI") == "true" {
-			log.SetColorProfile(termenv.TrueColor)
-		}
-
 	},
 }
 


### PR DESCRIPTION
enables logging at initialization, enabling logs where they were missing. Also rearranges where color is added to ensure none are missed.
![image](https://github.com/CircleCI-Public/slack-orb/assets/33272306/ae341607-ec6a-4a61-839a-3346a0230615)
