### PR TITLE
feat: pin version

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -337,6 +337,10 @@ jobs:
       - run:
           name: Validate Binary Version Change
           command: |
+            if [[ "$CIRCLE_TAG" ~= "dev" ]]; then
+              echo "Dev tag detected, skipping validation."
+              exit 0
+            fi
             excaped_expected_val="\<\< parameters.step_name \>\>"
             expected_val=$(echo "$excaped_expected_val" | sed -e's/\//\\\//g')
             CONFIGURED_BIN_VERSION=$(cat packages/orb/commands/notify.yml | yq '.steps[] | select(.run.name =="$expected_val") | .run.environment.SLACK_STR_BIN_VERSION')

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -202,31 +202,6 @@ jobs:
                 }
               ]
             }
-      - slack/notify:
-          debug: true
-          ignore_errors: false
-          step_name: "Test custom override URL"
-          event: always
-          bin_override_url: "https://github.com/CircleCI-Public/slack-orb-go/releases/download/v0.2.5/slack-orb-go_Linux_x86_64"
-          template_inline: >
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Current Job: $CIRCLE_JOB"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "this message was sent using override url build v0.2.5"
-                  }
-                }
-              ]
-            }
       - run:
           name: Dynamically populate the mention and export the template as an environment variable
           command: |
@@ -334,6 +309,34 @@ jobs:
                   "text": {
                     "type": "mrkdwn",
                     "text": "This message should show a backslash: $BACKSLASHES_STRING"
+                  }
+                }
+              ]
+            }
+      - run:
+          name: Clear binary from cache
+          command: rm -rf ./.circleci/orbs/circleci/slack/
+      - slack/notify:
+          debug: true
+          ignore_errors: false
+          step_name: "Test custom override URL"
+          event: always
+          bin_override_url: "https://github.com/CircleCI-Public/slack-orb-go/releases/download/v0.2.5/slack-orb-go_Linux_x86_64"
+          template_inline: >
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Current Job: $CIRCLE_JOB"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "this message was sent using override url build v0.2.5"
                   }
                 }
               ]

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -366,8 +366,8 @@ jobs:
               echo "Dev tag detected, skipping validation."
               exit 0
             fi
-            excaped_expected_val="\<\< parameters.step_name \>\>"
-            expected_val=$(echo "$excaped_expected_val" | sed -e's/\//\\\//g')
+            escaped_expected_val="\<\< parameters.step_name \>\>"
+            expected_val=$(echo "$escaped_expected_val" | sed -e's/\//\\\//g')
             CONFIGURED_BIN_VERSION=$(cat packages/orb/commands/notify.yml | yq '.steps[] | select(.run.name =="$expected_val") | .run.environment.SLACK_STR_BIN_VERSION')
             if [[ "$CONFIGURED_BIN_VERSION" != "$CIRCLE_TAG" ]]; then
               echo "The current release tag does not match the pinned version in the orb source."

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -341,11 +341,6 @@ jobs:
                 }
               ]
             }
-      - run:
-          name: Export value to file
-          command: |
-            printf '%s\n' "Hello There!" > /tmp/msg
-          when: always
   build-release:
     executor:
       name: go/default

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -202,6 +202,31 @@ jobs:
                 }
               ]
             }
+      - slack/notify:
+          debug: true
+          ignore_errors: false
+          step_name: "Test custom override URL"
+          event: always
+          bin_override_url: "https://github.com/CircleCI-Public/slack-orb-go/releases/download/v0.2.5/slack-orb-go_Linux_x86_64"
+          template_inline: >
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Current Job: $CIRCLE_JOB"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "this message was sent using override url build v0.2.5"
+                  }
+                }
+              ]
+            }
       - run:
           name: Dynamically populate the mention and export the template as an environment variable
           command: |

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -330,6 +330,22 @@ jobs:
           validate-yaml: true
           project-path: "$HOME/project/packages/cli"
           github-token: GHI_TOKEN
+  pre-deploy-validation:
+    executor: cimg
+    steps:
+      - checkout
+      - run:
+          name: Validate Binary Version Change
+          command: |
+            excaped_expected_val="\<\< parameters.step_name \>\>"
+            expected_val=$(echo "$excaped_expected_val" | sed -e's/\//\\\//g')
+            CONFIGURED_BIN_VERSION=$(cat packages/orb/commands/notify.yml | yq '.steps[] | select(.run.name =="$expected_val") | .run.environment.SLACK_STR_BIN_VERSION')
+            if [[ "$CONFIGURED_BIN_VERSION" != "$CIRCLE_TAG" ]]; then
+              echo "The current release tag does not match the pinned version in the orb source."
+              echo "Please delete this tag, update the pinned binary version in the orb source, and re-trigger a new release."
+              exit 1
+            fi
+
 workflows:
   test-deploy:
     jobs:
@@ -349,11 +365,13 @@ workflows:
           matrix:
             parameters:
               runner: [cimg, windows, alpine]
+      - pre-deploy-validation:
+          filters: *release-filters
       - orb-tools/pack:
           source_dir: packages/orb
           filters: *release-filters
       - build-release:
-          requires: [integration-test-templates, orb-tools/pack]
+          requires: [integration-test-templates, pre-deploy-validation, orb-tools/pack]
           context: orb-publisher
           filters: *release-filters
       - orb-tools/publish:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -314,12 +314,12 @@ jobs:
               ]
             }
       - run:
-          name: Clear binary from cache
-          command: rm -rf ./.circleci/orbs/circleci/slack/
+          name: Clear binary from Linux cache
+          command: rm -rf ./.circleci/orbs/circleci/slack/Linux
       - slack/notify:
           debug: true
           ignore_errors: false
-          step_name: "Test custom override URL"
+          step_name: "Test custom override URL (Linux)"
           event: always
           bin_override_url: "https://github.com/CircleCI-Public/slack-orb-go/releases/download/v0.2.5/slack-orb-go_Linux_x86_64"
           template_inline: >

--- a/packages/orb/commands/notify.yml
+++ b/packages/orb/commands/notify.yml
@@ -93,6 +93,12 @@ parameters:
     description: |
       Provide a SHA256 value to validate the binary utilized by this orb. By default, no validation is performed.
       You can locate the SHA256 value for the matching version of this orb in the GitHub release via the checksums.txt file.
+  bin_override_url:
+    type: string
+    default: ""
+    description: |
+      Provide a URL to download a specific build of the Slack Orb CLI binary. This is useful if you are behind a firewall or need to test a specific build in your pipeline.
+      This URL must be publicly accessible from the CircleCI build environment.
 steps:
   - run:
       when: on_fail
@@ -123,4 +129,5 @@ steps:
         SLACK_PARAM_CIRCLECI_HOST: "<<parameters.circleci_host>>"
         SLACK_PARAM_SHA256: "<<parameters.sha256>>"
         SLACK_STR_BIN_VERSION: "v1.0.0"
+        SLACK_STR_BIN_OVERRIDE_URL: "<<parameters.bin_override_url>>"
       command: <<include(scripts/main.sh)>>

--- a/packages/orb/commands/notify.yml
+++ b/packages/orb/commands/notify.yml
@@ -122,4 +122,5 @@ steps:
         SLACK_PARAM_DEBUG: "<<parameters.debug>>"
         SLACK_PARAM_CIRCLECI_HOST: "<<parameters.circleci_host>>"
         SLACK_PARAM_SHA256: "<<parameters.sha256>>"
+        SLACK_STR_BIN_VERSION: "v1.0.0"
       command: <<include(scripts/main.sh)>>

--- a/packages/orb/scripts/main.sh
+++ b/packages/orb/scripts/main.sh
@@ -109,6 +109,8 @@ orb_bin_dir="$base_dir/.circleci/orbs/circleci/slack/$PLATFORM/$ARCH"
 bin_name="slack-orb-go"
 repo_org="CircleCI-Public"
 repo_name="slack-orb-go"
+repo_url=""
+repo_source_location="" # reference for error message
 binary="$orb_bin_dir/$bin_name"
 input_sha256=$(circleci env subst "$SLACK_PARAM_SHA256")
 
@@ -121,14 +123,22 @@ if [ ! -f "$binary" ]; then
   fi
   printf '%s\n' "HTTP client: $HTTP_CLIENT."
 
-  print_debug "Slack orb binary version selected: $SLACK_STR_BIN_VERSION"
+  if [ -z "$SLACK_STR_BIN_OVERRIDE_URL" ]; then
+    print_debug "Slack orb binary version selected: $SLACK_STR_BIN_VERSION"
+    repo_url="https://github.com/$repo_org/$repo_name/releases/download/$SLACK_STR_BIN_VERSION/${repo_name}_${PLATFORM}_${ARCH}"
+    repo_source_location="GitHub Release: $repo_url"
+  else
+    print_debug "Slack orb binary URL override: $SLACK_STR_BIN_OVERRIDE_URL"
+    repo_url="$SLACK_STR_BIN_OVERRIDE_URL"
+    repo_source_location="URL override: $SLACK_STR_BIN_OVERRIDE_URL"
+  fi
 
-  repo_url="https://github.com/$repo_org/$repo_name/releases/download/$SLACK_STR_BIN_VERSION/${repo_name}_${PLATFORM}_${ARCH}"
+  
   [ "$PLATFORM" = "Windows" ] && repo_url="$repo_url.exe"
   printf '%s\n' "Release URL: $repo_url."
 
   if ! download_binary "$binary" "$repo_url" "$HTTP_CLIENT"; then
-    printf '%s\n' "Failed to download $repo_name binary from GitHub."
+    printf '%s\n' "Failed to download $repo_name binary from $repo_source_location."
     exit 1
   fi
 

--- a/packages/orb/scripts/main.sh
+++ b/packages/orb/scripts/main.sh
@@ -51,21 +51,6 @@ detect_arch() {
   esac
 }
 
-# Determine the latest version of a GitHub release.
-# $1: The GitHub organization
-# $2: The GitHub repository
-# $3: The HTTP client to use (curl or wget)
-determine_release_latest_version() {
-  if [ "$3" = "curl" ]; then
-    LATEST_VERSION="$(curl --fail --retry 3 -Ls -o /dev/null -w '%{url_effective}' "https://github.com/$1/$2/releases/latest" | sed 's:.*/::')"
-  elif [ "$3" = "wget" ]; then
-    LATEST_VERSION="$(wget -qO- "https://api.github.com/repos/$1/$2/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')"
-  else
-    printf '%s\n' "Invalid HTTP client specified."
-    return 1
-  fi
-}
-
 # Print a warning message
 # $1: The warning message to print
 print_warn() {
@@ -136,14 +121,9 @@ if [ ! -f "$binary" ]; then
   fi
   printf '%s\n' "HTTP client: $HTTP_CLIENT."
 
-  if ! determine_release_latest_version "$repo_org" "$repo_name" "$HTTP_CLIENT"; then
-    printf '%s\n' "Failed to determine latest version."
-    exit 1
-  fi
-  printf '%s\n' "Release's latest version: $LATEST_VERSION."
+  print_debug "Slack orb binary version selected: $SLACK_STR_BIN_VERSION"
 
-  # TODO: Make the version configurable via command parameter
-  repo_url="https://github.com/$repo_org/$repo_name/releases/download/$LATEST_VERSION/${repo_name}_${PLATFORM}_${ARCH}"
+  repo_url="https://github.com/$repo_org/$repo_name/releases/download/$SLACK_STR_BIN_VERSION/${repo_name}_${PLATFORM}_${ARCH}"
   [ "$PLATFORM" = "Windows" ] && repo_url="$repo_url.exe"
   printf '%s\n' "Release URL: $repo_url."
 


### PR DESCRIPTION
Changes:

1. Adds check to CI to force us to update the pinned binary version before publication
  a. Validation will skip if the published tag contains `dev` in the name.
3. Adds a new parameter allowing for a specific download URL
  a. Useful for server customers behind the firewall
  b. Useful for testing custom builds